### PR TITLE
rest-swagger: add missing bit to connector template, rework component proxy and customizers

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/ConnectorTemplate.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/ConnectorTemplate.java
@@ -16,12 +16,15 @@
 package io.syndesis.common.model.connection;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.syndesis.common.model.Kind;
+import io.syndesis.common.model.WithDependencies;
 import io.syndesis.common.model.WithId;
 import io.syndesis.common.model.WithName;
 import io.syndesis.common.model.WithProperties;
@@ -31,7 +34,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonDeserialize(builder = ConnectorTemplate.Builder.class)
 @SuppressWarnings("immutables")
-public interface ConnectorTemplate extends WithId<ConnectorTemplate>, WithName, WithProperties, Serializable {
+public interface ConnectorTemplate extends WithId<ConnectorTemplate>, WithName, WithDependencies, WithProperties, Serializable {
 
     class Builder extends ImmutableConnectorTemplate.Builder implements WithPropertiesBuilder<Builder> {
         // make ImmutableConnectorTemplate.Builder accessible
@@ -42,6 +45,13 @@ public interface ConnectorTemplate extends WithId<ConnectorTemplate>, WithName, 
     }
 
     String getComponentSchema();
+
+    Optional<String> getConnectorFactory();
+
+    @Value.Default
+    default List<String> getConnectorCustomizers() {
+        return Collections.emptyList();
+    }
 
     Optional<ConnectorGroup> getConnectorGroup();
 

--- a/app/connector/rest-swagger/pom.xml
+++ b/app/connector/rest-swagger/pom.xml
@@ -34,13 +34,11 @@
     <dependency>
       <groupId>io.syndesis.integration</groupId>
       <artifactId>integration-component-proxy</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>io.syndesis.connector</groupId>
       <artifactId>connector-support-processor</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -71,7 +69,7 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-rest-swagger</artifactId>
-      <scope>provided</scope>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SpecificationResourceCustomizer.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SpecificationResourceCustomizer.java
@@ -24,30 +24,38 @@ import java.util.Map;
 
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
-
+import org.apache.camel.util.ObjectHelper;
 import org.apache.commons.io.IOUtils;
 
 public final class SpecificationResourceCustomizer implements ComponentProxyCustomizer {
 
     @Override
     public void customize(final ComponentProxyComponent component, final Map<String, Object> options) {
-        consumeOption(options, "specification", specificationObject -> {
-            final String specification = (String) specificationObject;
+        String specification = null;
 
-            try {
-                final File tempSpecification = File.createTempFile("rest-swagger", ".json");
-                tempSpecification.deleteOnExit();
-                final String swaggerSpecificationPath = tempSpecification.getAbsolutePath();
+        // this is always true but it is needed to avoid spotbugs' BC_UNCONFIRMED_CAST
+        if (component instanceof SwaggerConnectorComponent) {
+            specification = ((SwaggerConnectorComponent)component).getSpecification();
+        }
+        if (ObjectHelper.isEmpty(specification)) {
+            specification = (String) options.remove("specification");
+        }
+        if (ObjectHelper.isEmpty(specification)) {
+            throw new IllegalArgumentException("No specification defined");
+        }
 
-                try (OutputStream out = new FileOutputStream(swaggerSpecificationPath)) {
-                    IOUtils.write(specification, out, StandardCharsets.UTF_8);
-                }
+        try {
+            final File tempSpecification = File.createTempFile("rest-swagger", ".json");
+            final String swaggerSpecificationPath = tempSpecification.getAbsolutePath();
 
-                options.put("specificationUri", swaggerSpecificationPath);
-            } catch (final IOException e) {
-                throw new IllegalStateException("Unable to persist the specification to filesystem", e);
+            try (OutputStream out = new FileOutputStream(swaggerSpecificationPath)) {
+                IOUtils.write(specification, out, StandardCharsets.UTF_8);
             }
-        });
+
+            options.put("specificationUri", "file:" + swaggerSpecificationPath);
+        } catch (final IOException e) {
+            throw new IllegalStateException("Unable to persist the specification to filesystem", e);
+        }
     }
 
 }

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SwaggerConnectorComponent.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SwaggerConnectorComponent.java
@@ -15,15 +15,15 @@
  */
 package io.syndesis.connector.rest.swagger;
 
-import io.syndesis.integration.component.proxy.ComponentDefinition;
-import io.syndesis.integration.component.proxy.ComponentProxyComponent;
-import org.apache.camel.Endpoint;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import io.syndesis.integration.component.proxy.ComponentDefinition;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import org.apache.camel.Endpoint;
 
 public final class SwaggerConnectorComponent extends ComponentProxyComponent {
 
@@ -51,12 +51,8 @@ public final class SwaggerConnectorComponent extends ComponentProxyComponent {
 
     private String username;
 
-    public SwaggerConnectorComponent() {
-        this(null);
-    }
-
-    public SwaggerConnectorComponent(final String componentSchema) {
-        super("swagger-connector", componentSchema);
+    public SwaggerConnectorComponent(final String componentId, final String componentSchema) {
+        super(componentId, componentSchema);
     }
 
     public String getAccessToken() {
@@ -170,8 +166,6 @@ public final class SwaggerConnectorComponent extends ComponentProxyComponent {
     @Override
     protected Endpoint createDelegateEndpoint(ComponentDefinition definition, String scheme, Map<String, String> options) throws Exception {
         final Endpoint endpoint = super.createDelegateEndpoint(definition, scheme, options);
-
-
 
         if (authenticationType == AuthenticationType.oauth2 && refreshToken != null && !refreshTokenRetryStatuses.isEmpty()) {
             Configuration configuration = (Configuration)getOption("xxx");

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SwaggerConnectorFactory.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SwaggerConnectorFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.rest.swagger;
+
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyFactory;
+
+public class SwaggerConnectorFactory implements ComponentProxyFactory {
+    @Override
+    public ComponentProxyComponent newInstance(String componentId, String componentScheme) {
+        return new SwaggerConnectorComponent(componentId, componentScheme);
+    }
+}

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/ConnectorGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/ConnectorGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     http:www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -38,9 +38,9 @@ public abstract class ConnectorGenerator {
     protected final Connector baseConnectorFrom(final ConnectorTemplate connectorTemplate, final ConnectorSettings connectorSettings) {
         final Set<String> properties = connectorTemplate.getProperties().keySet();
 
-        final Map<String, String> configuredProperties = connectorSettings.getConfiguredProperties()//
-            .entrySet().stream()//
-            .filter(e -> properties.contains(e.getKey()))//
+        final Map<String, String> configuredProperties = connectorSettings.getConfiguredProperties()
+            .entrySet().stream()
+            .filter(e -> properties.contains(e.getKey()))
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
         final String name = Optional.ofNullable(connectorSettings.getName())
@@ -58,14 +58,17 @@ public abstract class ConnectorGenerator {
             icon = IconGenerator.generate(connectorTemplate.getId().get(), name);
         }
 
-        return new Connector.Builder()//
-            .id(KeyGenerator.createKey())//
-            .name(name)//
-            .description(description)//
-            .icon(icon)//
-            .configuredProperties(configuredProperties)//
-            .connectorGroup(connectorGroup)//
-            .connectorGroupId(connectorGroup.map(ConnectorGroup::getId).orElse(Optional.empty()))//
+        return new Connector.Builder()
+            .id(KeyGenerator.createKey())
+            .name(name)
+            .description(description)
+            .icon(icon)
+            .configuredProperties(configuredProperties)
+            .connectorGroup(connectorGroup)
+            .connectorGroupId(connectorGroup.map(ConnectorGroup::getId).orElse(Optional.empty()))
+            .addAllDependencies(connectorTemplate.getDependencies())
+            .addAllConnectorCustomizers(connectorTemplate.getConnectorCustomizers())
+            .connectorFactory(connectorTemplate.getConnectorFactory())
             .build();
     }
 

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
@@ -19,11 +19,13 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.models.Info;
 import io.swagger.models.Operation;
 import io.swagger.models.Path;
 import io.swagger.models.Swagger;
 import io.swagger.models.parameters.Parameter;
+import io.syndesis.common.model.Dependency;
 import io.syndesis.common.model.action.ActionsSummary;
 import io.syndesis.common.model.action.ConnectorAction;
 import io.syndesis.common.model.action.ConnectorDescriptor;
@@ -32,14 +34,10 @@ import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.connection.ConnectorSettings;
 import io.syndesis.common.util.openapi.OpenApiHelper;
-
 import org.junit.Test;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import static io.syndesis.server.api.generator.swagger.TestHelper.reformatJson;
 import static io.syndesis.server.api.generator.swagger.TestHelper.resource;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorTest {
@@ -50,6 +48,38 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
             return new ConnectorDescriptor.Builder();
         }
     };
+
+    @Test
+    public void includesRestSwaggerConnectorDependency() throws IOException {
+        final ConnectorSettings connectorSettings = createReverbSettings();
+        final Connector connector = generator.generate(SWAGGER_TEMPLATE, connectorSettings);
+
+        assertThat(connector.getDependencies()).isNotEmpty();
+        assertThat(connector.getDependencies()).anyMatch(d -> d.getType() == Dependency.Type.MAVEN && d.getId().startsWith("io.syndesis.connector:connector-rest-swagger"));
+    }
+
+    @Test
+    public void includesRestSwaggerConnectorCustomizers() throws IOException {
+        final ConnectorSettings connectorSettings = createReverbSettings();
+        final Connector connector = generator.generate(SWAGGER_TEMPLATE, connectorSettings);
+
+        assertThat(connector.getConnectorCustomizers()).isNotEmpty();
+        assertThat(connector.getConnectorCustomizers()).contains(
+            "io.syndesis.connector.rest.swagger.SpecificationResourceCustomizer",
+            "io.syndesis.connector.rest.swagger.AuthenticationCustomizer",
+            "io.syndesis.connector.rest.swagger.RequestCustomizer",
+            "io.syndesis.connector.rest.swagger.ResponseCustomizer"
+        );
+    }
+
+    @Test
+    public void includesRestSwaggerConnectorFactory() throws IOException {
+        final ConnectorSettings connectorSettings = createReverbSettings();
+        final Connector connector = generator.generate(SWAGGER_TEMPLATE, connectorSettings);
+
+        assertThat(connector.getConnectorFactory()).isPresent();
+        assertThat(connector.getConnectorFactory()).hasValue("io.syndesis.connector.rest.swagger.SwaggerConnectorFactory");
+    }
 
     @Test
     public void shouldCreatePropertyParametersFromPetstoreSwagger() throws IOException {
@@ -237,6 +267,15 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
     private static ConnectorSettings createSettingsFrom(final Swagger swagger) {
         return new ConnectorSettings.Builder()//
             .putConfiguredProperty("specification", OpenApiHelper.serialize(swagger))//
+            .build();
+    }
+
+    private static ConnectorSettings createReverbSettings() throws IOException {
+        return new ConnectorSettings.Builder()
+            .name("Reverb API")
+            .description("Invokes Reverb API")
+            .icon("fa-music")
+            .putConfiguredProperty("specification", resource("/swagger/reverb.swagger.yaml"))
             .build();
     }
 

--- a/app/server/dao/src/main/resources/io/syndesis/server/dao/deployment.json
+++ b/app/server/dao/src/main/resources/io/syndesis/server/dao/deployment.json
@@ -75,6 +75,19 @@
   {
     "data": {
       "componentSchema": "rest-swagger",
+      "dependencies": [
+        {
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+          "type": "MAVEN"
+        }
+      ],
+      "connectorFactory": "io.syndesis.connector.rest.swagger.SwaggerConnectorFactory",
+      "connectorCustomizers": [
+        "io.syndesis.connector.rest.swagger.SpecificationResourceCustomizer",
+        "io.syndesis.connector.rest.swagger.AuthenticationCustomizer",
+        "io.syndesis.connector.rest.swagger.RequestCustomizer",
+        "io.syndesis.connector.rest.swagger.ResponseCustomizer"
+      ],
       "connectorGroup": {
         "id": "swagger-connector-template"
       },


### PR DESCRIPTION
It still need to be polished a lot but at least now the integration starts.

Some open points:
- not sure if the concept of connector template still make sense, it could be a standard connector eventually hidden
- there is some overlapping of functionalities between customizers and connector (i.e. the specification is set on the connector but used by a customizer)